### PR TITLE
feat: 双方向通信機能の完全実装（Slack↔Lark）

### DIFF
--- a/packages/lark-slack-connector/src/cli/desktop.ts
+++ b/packages/lark-slack-connector/src/cli/desktop.ts
@@ -17,10 +17,14 @@ interface DesktopConfig {
   slackBotToken: string;
   slackAppToken: string;
   slackSigningSecret?: string;
+  slackUserToken?: string; // For sending as user (松井大樹)
   larkWebhookUrl: string;
   larkAppId?: string;
   larkAppSecret?: string;
   serverPort?: number;
+  // Bidirectional settings
+  sendAsUser?: boolean; // Send messages as user instead of bot
+  defaultSlackChannel?: string; // Default channel for Lark→Slack
 }
 
 function sendStatus(status: BridgeStatus): void {
@@ -103,6 +107,7 @@ function createBridgeConfig(desktop: DesktopConfig): BridgeConfig {
           botToken: desktop.slackBotToken,
           signingSecret: desktop.slackSigningSecret || 'dummy-signing-secret',
           appToken: desktop.slackAppToken,
+          userToken: desktop.slackUserToken,
         },
       ],
       socketMode: true,
@@ -112,6 +117,11 @@ function createBridgeConfig(desktop: DesktopConfig): BridgeConfig {
       appId: desktop.larkAppId,
       appSecret: desktop.larkAppSecret,
     },
+    // Sender configuration for bidirectional messaging
+    sender: {
+      sendAsUser: desktop.sendAsUser ?? true, // Default to sending as user
+      slackUserToken: desktop.slackUserToken,
+    },
     options: {
       includeChannelName: true,
       includeUserName: true,
@@ -120,6 +130,7 @@ function createBridgeConfig(desktop: DesktopConfig): BridgeConfig {
       includeThreadReplies: true,
       slackConnectPolling: false,
       pollingIntervalMs: 5000,
+      defaultSlackChannel: desktop.defaultSlackChannel,
       maxRetries: 3,
       retryDelayMs: 1000,
       logLevel: 'info',

--- a/packages/lark-slack-connector/src/lark/client.ts
+++ b/packages/lark-slack-connector/src/lark/client.ts
@@ -118,11 +118,15 @@ export class LarkClient {
 
   /**
    * Handle incoming Lark event (for webhook receiver)
+   * Supports both v1 and v2 event formats
    */
   async handleEvent(event: Record<string, unknown>): Promise<void> {
-    // Verify event if verification token is configured
-    if (this.config.verificationToken) {
-      const token = event.token as string | undefined;
+    // Log incoming event for debugging
+    this.log('debug', `Received Lark event: ${JSON.stringify(event).slice(0, 200)}...`);
+
+    // Verify event if verification token is configured (v1 format)
+    if (this.config.verificationToken && event.token) {
+      const token = event.token as string;
       if (token !== this.config.verificationToken) {
         throw new Error('Invalid verification token');
       }
@@ -133,8 +137,82 @@ export class LarkClient {
       return;
     }
 
-    // Handle message events
+    // Detect event format (v1 or v2)
+    const isV2Format = event.schema === '2.0' || event.header;
+
+    if (isV2Format) {
+      await this.handleV2Event(event);
+    } else {
+      await this.handleV1Event(event);
+    }
+  }
+
+  /**
+   * Handle v2 format events (newer Lark API)
+   */
+  private async handleV2Event(event: Record<string, unknown>): Promise<void> {
+    const header = event.header as Record<string, unknown> | undefined;
     const eventData = event.event as Record<string, unknown> | undefined;
+
+    if (!header || !eventData) {
+      this.log('warn', 'Invalid v2 event format');
+      return;
+    }
+
+    const eventType = header.event_type as string;
+    this.log('debug', `Processing v2 event type: ${eventType}`);
+
+    // Handle message events
+    if (eventType === 'im.message.receive_v1') {
+      const message = eventData.message as Record<string, unknown>;
+      const sender = eventData.sender as Record<string, unknown> | undefined;
+
+      if (!message) {
+        this.log('warn', 'No message in event data');
+        return;
+      }
+
+      // Get sender info
+      let senderName: string | undefined;
+      const senderId = sender?.sender_id as Record<string, unknown> | undefined;
+      const senderIdValue = senderId?.open_id as string || senderId?.user_id as string;
+
+      // Try to get sender name from API if we have a client
+      if (this.client && senderIdValue) {
+        try {
+          const userInfo = await this.client.contact.user.get({
+            params: { user_id_type: 'open_id' },
+            path: { user_id: senderIdValue },
+          });
+          senderName = userInfo.data?.user?.name;
+        } catch {
+          // Ignore errors fetching user info
+        }
+      }
+
+      const larkMessage: LarkMessage = {
+        chatId: message.chat_id as string,
+        senderId: senderIdValue,
+        senderName,
+        content: this.extractTextContent(message.content as string),
+        messageId: message.message_id as string,
+        parentId: message.parent_id as string | undefined,
+      };
+
+      this.log('info', `Received Lark message from ${senderName || senderIdValue || 'unknown'}: ${larkMessage.content.slice(0, 50)}...`);
+
+      for (const handler of this.messageHandlers) {
+        await handler(larkMessage);
+      }
+    }
+  }
+
+  /**
+   * Handle v1 format events (legacy)
+   */
+  private async handleV1Event(event: Record<string, unknown>): Promise<void> {
+    const eventData = event.event as Record<string, unknown> | undefined;
+
     if (eventData?.message) {
       const message = eventData.message as Record<string, unknown>;
       const sender = eventData.sender as Record<string, unknown> | undefined;
@@ -142,7 +220,7 @@ export class LarkClient {
       const larkMessage: LarkMessage = {
         chatId: message.chat_id as string,
         senderId: sender?.sender_id as string | undefined,
-        senderName: sender?.sender_id as string | undefined, // Would need API call to get name
+        senderName: sender?.sender_id as string | undefined,
         content: this.extractTextContent(message.content as string),
         messageId: message.message_id as string,
         parentId: message.parent_id as string | undefined,
@@ -151,6 +229,13 @@ export class LarkClient {
       for (const handler of this.messageHandlers) {
         await handler(larkMessage);
       }
+    }
+  }
+
+  private log(level: 'debug' | 'info' | 'warn' | 'error', message: string): void {
+    const levels = ['debug', 'info', 'warn', 'error'];
+    if (levels.indexOf(level) >= levels.indexOf(this.logLevel)) {
+      console[level](`[LarkClient] ${message}`);
     }
   }
 

--- a/packages/lark-slack-connector/src/types/index.ts
+++ b/packages/lark-slack-connector/src/types/index.ts
@@ -7,10 +7,21 @@ export const SlackWorkspaceSchema = z.object({
   botToken: z.string().min(1, 'Slack bot token is required'),
   signingSecret: z.string().min(1, 'Slack signing secret is required'),
   appToken: z.string().optional(), // For Socket Mode
-  userToken: z.string().optional(), // For Slack Connect
+  userToken: z.string().optional(), // For Slack Connect and sending as user
+});
+
+// Sender configuration for messages
+export const SenderConfigSchema = z.object({
+  // Use user token instead of bot token for sending
+  sendAsUser: z.boolean().default(false),
+  // Slack user token for sending as specific user
+  slackUserToken: z.string().optional(),
+  // Lark user access token (if available)
+  larkUserAccessToken: z.string().optional(),
 });
 
 export type SlackWorkspace = z.infer<typeof SlackWorkspaceSchema>;
+export type SenderConfig = z.infer<typeof SenderConfigSchema>;
 
 // Lark Configuration
 export const LarkConfigSchema = z.object({
@@ -55,6 +66,9 @@ export const BridgeConfigSchema = z.object({
   // Lark settings
   lark: LarkConfigSchema,
 
+  // Sender settings (for sending as specific user)
+  sender: SenderConfigSchema.optional(),
+
   // Channel mappings
   channelMappings: z.array(ChannelMappingSchema).optional(),
 
@@ -75,6 +89,9 @@ export const BridgeConfigSchema = z.object({
     // Polling for Slack Connect
     slackConnectPolling: z.boolean().default(false),
     pollingIntervalMs: z.number().default(5000),
+
+    // Default Slack channel for Lark→Slack messages (when no mapping found)
+    defaultSlackChannel: z.string().optional(),
 
     // Retry settings
     maxRetries: z.number().default(3),

--- a/packages/lark-slack-desktop/src/App.tsx
+++ b/packages/lark-slack-desktop/src/App.tsx
@@ -21,7 +21,13 @@ interface Config {
   slackBotToken: string;
   slackAppToken: string;
   slackSigningSecret: string;
+  slackUserToken: string; // For sending as user (松井大樹)
   larkWebhookUrl: string;
+  larkAppId: string;
+  larkAppSecret: string;
+  // Bidirectional settings
+  sendAsUser: boolean;
+  defaultSlackChannel: string;
 }
 
 // Tauri invoke wrapper - lazy loaded on first use
@@ -67,7 +73,12 @@ function App() {
     slackBotToken: '',
     slackAppToken: '',
     slackSigningSecret: '',
+    slackUserToken: '',
     larkWebhookUrl: '',
+    larkAppId: '',
+    larkAppSecret: '',
+    sendAsUser: true,
+    defaultSlackChannel: '',
   });
   const [isLoading, setIsLoading] = useState(false);
   const [isTesting, setIsTesting] = useState(false);
@@ -393,13 +404,33 @@ function App() {
                   🐦 Lark
                 </h3>
                 <div className="form-group">
-                  <label className="form-label">Webhook URL</label>
+                  <label className="form-label">Webhook URL (Slack→Lark送信用)</label>
                   <input
                     type="text"
                     className="form-input"
                     value={config.larkWebhookUrl}
                     onChange={(e) => setConfig(prev => ({ ...prev, larkWebhookUrl: e.target.value }))}
                     placeholder="https://open.larksuite.com/..."
+                  />
+                </div>
+                <div className="form-group">
+                  <label className="form-label">App ID (Lark→Slack受信用、オプション)</label>
+                  <input
+                    type="text"
+                    className="form-input"
+                    value={config.larkAppId}
+                    onChange={(e) => setConfig(prev => ({ ...prev, larkAppId: e.target.value }))}
+                    placeholder="cli_xxxxx"
+                  />
+                </div>
+                <div className="form-group">
+                  <label className="form-label">App Secret (オプション)</label>
+                  <input
+                    type="password"
+                    className="form-input"
+                    value={config.larkAppSecret}
+                    onChange={(e) => setConfig(prev => ({ ...prev, larkAppSecret: e.target.value }))}
+                    placeholder="App Secret..."
                   />
                 </div>
                 <button
@@ -412,15 +443,58 @@ function App() {
                 </button>
               </div>
 
+              <div style={{ marginTop: 20 }}>
+                <h3 style={{ fontSize: 13, marginBottom: 12, color: 'var(--accent)' }}>
+                  🔄 双方向通信設定
+                </h3>
+                <div className="form-group">
+                  <label className="form-label">Slack User Token (松井大樹アカウント用)</label>
+                  <input
+                    type="password"
+                    className="form-input"
+                    value={config.slackUserToken}
+                    onChange={(e) => setConfig(prev => ({ ...prev, slackUserToken: e.target.value }))}
+                    placeholder="xoxp-..."
+                  />
+                  <small style={{ color: 'var(--text-secondary)', fontSize: 11 }}>
+                    Lark→Slackの送信時、このアカウントで送信されます
+                  </small>
+                </div>
+                <div className="form-group">
+                  <label className="form-label">デフォルトSlackチャンネル (Lark→Slack)</label>
+                  <input
+                    type="text"
+                    className="form-input"
+                    value={config.defaultSlackChannel}
+                    onChange={(e) => setConfig(prev => ({ ...prev, defaultSlackChannel: e.target.value }))}
+                    placeholder="general または C0A2ZRFT6UU"
+                  />
+                  <small style={{ color: 'var(--text-secondary)', fontSize: 11 }}>
+                    Larkからのメッセージをデフォルトで送信するチャンネル
+                  </small>
+                </div>
+                <div className="form-group" style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <input
+                    type="checkbox"
+                    id="sendAsUser"
+                    checked={config.sendAsUser}
+                    onChange={(e) => setConfig(prev => ({ ...prev, sendAsUser: e.target.checked }))}
+                  />
+                  <label htmlFor="sendAsUser" style={{ fontSize: 12 }}>
+                    ユーザーアカウント（松井大樹）として送信
+                  </label>
+                </div>
+              </div>
+
               <div style={{ marginTop: 20, padding: 12, background: 'rgba(59, 130, 246, 0.1)', borderRadius: 8 }}>
                 <h4 style={{ fontSize: 12, marginBottom: 8, color: 'var(--accent)' }}>
                   📌 双方向通信について
                 </h4>
                 <p style={{ fontSize: 11, color: 'var(--text-secondary)', margin: 0, lineHeight: 1.5 }}>
-                  <strong>Slack → Lark:</strong> Socket Mode で自動受信<br />
+                  <strong>Slack → Lark:</strong> Socket Mode で自動受信、Webhookで送信<br />
                   <strong>Lark → Slack:</strong>
                   ローカルサーバー (port 3456) が起動します。
-                  Larkの「Webhook設定」で <code>http://your-ip:3456/lark/webhook</code> を設定してください。
+                  Larkの「Event Subscription」で <code>http://your-ip:3456/lark/webhook</code> を設定してください。
                 </p>
               </div>
             </div>


### PR DESCRIPTION
## Summary

- Lark Event Subscription受信サーバーをv1/v2形式に対応
- Lark→Slack通信時にユーザーアカウント（松井大樹）として送信する機能追加
- デスクトップアプリUIに双方向通信設定画面追加

## Changes

### packages/lark-slack-connector
- `src/types/index.ts`: `SenderConfig`スキーマと`defaultSlackChannel`オプション追加
- `src/slack/client.ts`: `sendMessageAsUser()`メソッドと`hasUserToken()`追加
- `src/lark/client.ts`: Event Subscription v2形式対応、ログ機能追加
- `src/bridge.ts`: SenderConfigを使用したユーザーアカウント送信対応
- `src/cli/desktop.ts`: 新しい設定オプション対応

### packages/lark-slack-desktop
- `src/App.tsx`: 双方向通信設定UI追加
  - Slack User Token設定
  - デフォルトSlackチャンネル設定
  - ユーザーアカウントとして送信のチェックボックス

## Test plan

- [x] TypeScriptビルド成功
- [x] ユニットテスト全パス（26 tests）
- [ ] Slack→Lark: メッセージ送信テスト
- [ ] Lark→Slack: メッセージ受信テスト
- [ ] ユーザーアカウント（松井大樹）として送信確認

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)